### PR TITLE
Add Primer ViewComponents to releases

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ const Octokit = require('@octokit/rest')
 const github = new Octokit({auth: process.env.GITHUB_TOKEN})
 
 const PACKAGES = [
-  {name: '@primer/css',         repo: 'primer/css'},
-  {name: '@primer/components',  repo: 'primer/components'},
-  {name: '@primer/octicons',    repo: 'primer/octicons'}
+  {name: '@primer/css',             repo: 'primer/css'},
+  {name: '@primer/components',      repo: 'primer/components'},
+  {name: '@primer/octicons',        repo: 'primer/octicons'},
+  {name: '@primer/view-components', repo: 'primer/view_components'}
 ].map(pkg => {
   pkg.url = `https://github.com/${pkg.repo}`
   return pkg

--- a/now.json
+++ b/now.json
@@ -2,10 +2,6 @@
   "version": 2,
   "name": "primer-releases",
   "alias": "releases.primer.style",
-  "builds": [{
-    "src": "server.js",
-    "use": "@now/node-server"
-  }],
   "env": {
     "GITHUB_TOKEN": "@github-release-token"
   }

--- a/now.json
+++ b/now.json
@@ -2,9 +2,10 @@
   "version": 2,
   "name": "primer-releases",
   "alias": "releases.primer.style",
-  "build": {
+  "builds": [{
+    "src": "server.js",
     "use": "@now/node-server"
-  },
+  }],
   "env": {
     "GITHUB_TOKEN": "@github-release-token"
   }

--- a/now.json
+++ b/now.json
@@ -3,7 +3,6 @@
   "name": "primer-releases",
   "alias": "releases.primer.style",
   "build": {
-    "src": "server.js",
     "use": "@now/node-server"
   },
   "env": {


### PR DESCRIPTION
We'd like to have PVC releases as part of https://primer.style/news/. This config will pull npm releases but that's okay since we release to npm at the same time we do to rubygems.